### PR TITLE
Handle unknown drag modes in chart card

### DIFF
--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -583,8 +583,9 @@ def build_chart_card(
     else:
         dtick = "M6"
     fig.update_xaxes(tickformat="%Y-%m", dtick=dtick)
+    dragmode_map = {"パン": "pan", "ズーム": "zoom", "選択": "select"}
     fig.update_layout(
-        dragmode={"パン": "pan", "ズーム": "zoom", "選択": "select"}[tb["op_mode"]],
+        dragmode=dragmode_map.get(tb.get("op_mode"), "pan"),
         hovermode="closest" if tb["hover_mode"] == "個別" else "x unified",
         legend=dict(
             orientation="h",


### PR DESCRIPTION
## Summary
- default the Plotly drag mode to pan when the toolbar setting is missing or unexpected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7fbb2f098832396ab3a00443e766e