### PR TITLE
Handle invalid dragmode values

### DIFF
--- a/app.py
+++ b/app.py
@@ -1068,7 +1068,11 @@ from sample_data import (
     load_sample_csv_dataframe,
     load_sample_dataset,
 )
-from core.chart_card import toolbar_sku_detail, build_chart_card
+from core.chart_card import (
+    VALID_PLOTLY_DRAGMODES,
+    build_chart_card,
+    toolbar_sku_detail,
+)
 from core.plot_utils import apply_elegant_theme, padded_range, render_plotly_with_spinner
 from core.correlation import (
     corr_table,
@@ -12402,9 +12406,12 @@ zスコア：全SKUの傾き分布に対する標準化。|z|≥1.5で急勾配�
     HALO = "#ffffff" if st.get_option("theme.base") == "dark" else "#222222"
     SZ = 6
     dtick = "M1"
-    drag = {"ズーム": "zoom", "パン": "pan", "選択": "select"}.get(
-        op_mode, "pan"
-    )
+    drag_lookup = {"ズーム": "zoom", "パン": "pan", "選択": "select"}
+    drag = drag_lookup.get(op_mode)
+    if drag is None and isinstance(op_mode, str):
+        drag = op_mode
+    if drag not in VALID_PLOTLY_DRAGMODES:
+        drag = "pan"
 
     st.subheader("スモールマルチプル")
     share_y = st.checkbox("Y軸共有", value=False)

--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -23,6 +23,19 @@ UNIT_SCALE = {"円": 1, "千円": 1_000, "百万円": 1_000_000}
 MAX_DISPLAY_PRODUCTS = 60
 TREND_POS_THRESHOLD = 0.05
 TREND_NEG_THRESHOLD = -0.05
+VALID_PLOTLY_DRAGMODES: set[str] = {
+    "zoom",
+    "pan",
+    "select",
+    "lasso",
+    "drawrect",
+    "drawcircle",
+    "drawline",
+    "drawopenpath",
+    "drawclosedpath",
+    "orbit",
+    "turntable",
+}
 
 
 def _sample_scale_colors(scale: list[str], count: int, *, low: float = 0.1, high: float = 0.9) -> list[str]:
@@ -584,8 +597,15 @@ def build_chart_card(
         dtick = "M6"
     fig.update_xaxes(tickformat="%Y-%m", dtick=dtick)
     dragmode_map = {"パン": "pan", "ズーム": "zoom", "選択": "select"}
+    raw_dragmode = tb.get("op_mode")
+    dragmode = dragmode_map.get(raw_dragmode)
+    if dragmode is None and isinstance(raw_dragmode, str):
+        dragmode = raw_dragmode
+    if dragmode not in VALID_PLOTLY_DRAGMODES:
+        dragmode = "pan"
+
     fig.update_layout(
-        dragmode=dragmode_map.get(tb.get("op_mode"), "pan"),
+        dragmode=dragmode,
         hovermode="closest" if tb["hover_mode"] == "個別" else "x unified",
         legend=dict(
             orientation="h",


### PR DESCRIPTION
## Summary
- ensure chart toolbar drag mode selections always resolve to Plotly-supported values
- share the valid drag mode list with the small-multiple view and fall back to panning when needed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7fd6ecee88323a4a105694b7f2149